### PR TITLE
Support authentication via SSH keys

### DIFF
--- a/src/main/groovy/org/ajoberstar/gradle/git/tasks/GitClone.java
+++ b/src/main/groovy/org/ajoberstar/gradle/git/tasks/GitClone.java
@@ -32,6 +32,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.repositories.AuthenticationSupported;
 import org.gradle.api.artifacts.repositories.PasswordCredentials;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.util.ConfigureUtil;
@@ -76,6 +77,7 @@ public class GitClone extends DefaultTask implements AuthenticationSupported {
 	 * @return the credentials
 	 */
 	@Input
+    @Optional
 	public PasswordCredentials getCredentials() {
 		return credentials;
 	}

--- a/src/main/groovy/org/ajoberstar/gradle/git/tasks/GitPush.java
+++ b/src/main/groovy/org/ajoberstar/gradle/git/tasks/GitPush.java
@@ -24,6 +24,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.artifacts.repositories.AuthenticationSupported;
 import org.gradle.api.artifacts.repositories.PasswordCredentials;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.util.ConfigureUtil;
 
@@ -67,6 +68,7 @@ public class GitPush extends GitBase implements AuthenticationSupported {
 	 * @return the credentials
 	 */
 	@Input
+    @Optional
 	public PasswordCredentials getCredentials() {
 		return credentials;
 	}


### PR DESCRIPTION
If the chosen remote URI supports it, JGit will default to SSH and use the keys registered in the user's `~/.ssh`.
That way, each user can use his own credentials without the need to specify his unencrypted password anywhere in the system.
The attached commit makes it optional to specify credentials for tasks that with a remote repository and thus enables key-based authentication in gradle-git.
