### PR TITLE
Enhancements to commit task

### DIFF
--- a/src/main/groovy/org/ajoberstar/gradle/git/tasks/GitCommit.java
+++ b/src/main/groovy/org/ajoberstar/gradle/git/tasks/GitCommit.java
@@ -15,11 +15,12 @@
 package org.ajoberstar.gradle.git.tasks;
 
 import groovy.lang.Closure;
-
 import org.ajoberstar.gradle.util.ObjectUtil;
 import org.eclipse.jgit.api.CommitCommand;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.gradle.api.GradleException;
+import org.gradle.api.file.FileVisitDetails;
+import org.gradle.api.file.FileVisitor;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskAction;
@@ -27,130 +28,155 @@ import org.gradle.util.ConfigureUtil;
 
 /**
  * Task to commit changes to a Git repository.
+ *
  * @since 0.1.0
  */
-public class GitCommit extends GitBase {
-	private Object message = null;
-	private boolean commitAll = false;
-	private PersonIdent committer = null;
-	private PersonIdent author = null;
-	
-	/**
-	 * Commits changes to the Git repository.
-	 */
-	@TaskAction
-	public void commit() {
-		CommitCommand cmd = getGit().commit();
-		cmd.setMessage(getMessage());
-		cmd.setAll(getCommitAll());
-		if (committer != null) {
-			cmd.setCommitter(getCommitter());
-		}
-		if (author != null) {
-			cmd.setAuthor(getAuthor());
-		}
-		try {
-			cmd.call();
-		} catch (Exception e) {
-			throw new GradleException("Problem committing changes.", e);
-		}
-	}
-	
-	/**
-	 * Gets the commit message to use.
-	 * @return the commit message to use
-	 */
-	@Input
-	public String getMessage() {
-		return ObjectUtil.unpackString(message);
-	}
-	
-	/**
-	 * Sets the commit message to use.
-	 * @param message the commit message
-	 */
-	public void setMessage(Object message) {
-		this.message = message;
-	}
-	
-	/**
-	 * Gets whether to commit all modified and deleted files.
-	 * New files will not be affected.
-	 * @return whether to commit all files
-	 */
-	@Input
-	public boolean getCommitAll() {
-		return commitAll;
-	}
-	
-	/**
-	 * Sets whether to commit all modified and deleted files.
-	 * New files will not be affected.
-	 * @param commitAll whetherh to commit all files
-	 */
-	public void setCommitAll(boolean commitAll) {
-		this.commitAll = commitAll;
-	}
-	
-	/**
-	 * Gets the committer to for this commit.
-	 * @return the committer
-	 */
-	@Input
-	@Optional
-	public PersonIdent getCommitter() {
-		return committer;
-	}
-	
-	/**
-	 * Sets the committer for this commit.
-	 * @param committer the committer
-	 */
-	public void setCommitter(PersonIdent committer) {
-		this.committer = committer;
-	}
-	
-	/**
-	 * Configures the committer for this commit.
-	 * A {@code PersonIdent} is passed to the closure.
-	 * @param config the configuration closure
-	 */
-	@SuppressWarnings("rawtypes") 
-	public void committer(Closure config) {
-		if (committer == null) {
-			this.committer = new PersonIdent(getGit().getRepository());
-		}
-		ConfigureUtil.configure(config, committer);
-	}
-	
-	/**
-	 * Gets the author for this commit.
-	 * @return the author
-	 */
-	@Input
-	@Optional
-	public PersonIdent getAuthor() {
-		return author;
-	}
-	
-	/**
-	 * Sets the author for this commit.
-	 * @param author the author
-	 */
-	public void setAuthor(PersonIdent author) {
-		this.author = author;
-	}
-	
-	/**
-	 * Configures the author for this commit.
-	 * A {@code PersonIdent} is passed to the closure.
-	 * @param config the configuration closure
-	 */
-	@SuppressWarnings("rawtypes") 
-	public void author(Closure config) {
-		if (author == null) {
-			this.author = new PersonIdent(getGit().getRepository());
-		}
-		ConfigureUtil.configure(config, author);
-	}
+public class GitCommit extends GitSource {
+
+    private Object message = null;
+    private boolean commitAll = false;
+    private PersonIdent committer = null;
+    private PersonIdent author = null;
+
+    /**
+     * Commits changes to the Git repository.
+     */
+    @TaskAction
+    public void commit() {
+        final CommitCommand cmd = getGit().commit();
+        cmd.setMessage(getMessage());
+        cmd.setAll(getCommitAll());
+        if (committer != null) {
+            cmd.setCommitter(getCommitter());
+        }
+        if (author != null) {
+            cmd.setAuthor(getAuthor());
+        }
+
+        if (!patternSet.getExcludes().isEmpty() || !patternSet.getIncludes().isEmpty()) {
+            getSource().visit(new FileVisitor() {
+                public void visitDir(FileVisitDetails arg0) {
+                    visitFile(arg0);
+                }
+
+                public void visitFile(FileVisitDetails arg0) {
+                    cmd.setOnly(arg0.getPath());
+                }
+            });
+        }
+
+        try {
+            cmd.call();
+        } catch (Exception e) {
+            throw new GradleException("Problem committing changes.", e);
+        }
+    }
+
+    /**
+     * Gets the commit message to use.
+     *
+     * @return the commit message to use
+     */
+    @Input
+    public String getMessage() {
+        return ObjectUtil.unpackString(message);
+    }
+
+    /**
+     * Sets the commit message to use.
+     *
+     * @param message the commit message
+     */
+    public void setMessage(Object message) {
+        this.message = message;
+    }
+
+    /**
+     * Gets whether to commit all modified and deleted files.
+     * New files will not be affected.
+     *
+     * @return whether to commit all files
+     */
+    @Input
+    public boolean getCommitAll() {
+        return commitAll;
+    }
+
+    /**
+     * Sets whether to commit all modified and deleted files.
+     * New files will not be affected.
+     *
+     * @param commitAll whetherh to commit all files
+     */
+    public void setCommitAll(boolean commitAll) {
+        this.commitAll = commitAll;
+    }
+
+    /**
+     * Gets the committer to for this commit.
+     *
+     * @return the committer
+     */
+    @Input
+    @Optional
+    public PersonIdent getCommitter() {
+        return committer;
+    }
+
+    /**
+     * Sets the committer for this commit.
+     *
+     * @param committer the committer
+     */
+    public void setCommitter(PersonIdent committer) {
+        this.committer = committer;
+    }
+
+    /**
+     * Configures the committer for this commit.
+     * A {@code PersonIdent} is passed to the closure.
+     *
+     * @param config the configuration closure
+     */
+    @SuppressWarnings("rawtypes")
+    public void committer(Closure config) {
+        if (committer == null) {
+            this.committer = new PersonIdent(getGit().getRepository());
+        }
+        ConfigureUtil.configure(config, committer);
+    }
+
+    /**
+     * Gets the author for this commit.
+     *
+     * @return the author
+     */
+    @Input
+    @Optional
+    public PersonIdent getAuthor() {
+        return author;
+    }
+
+    /**
+     * Sets the author for this commit.
+     *
+     * @param author the author
+     */
+    public void setAuthor(PersonIdent author) {
+        this.author = author;
+    }
+
+    /**
+     * Configures the author for this commit.
+     * A {@code PersonIdent} is passed to the closure.
+     *
+     * @param config the configuration closure
+     */
+    @SuppressWarnings("rawtypes")
+    public void author(Closure config) {
+        if (author == null) {
+            this.author = new PersonIdent(getGit().getRepository());
+        }
+        ConfigureUtil.configure(config, author);
+    }
 }

--- a/src/test/groovy/org/ajoberstar/gradle/git/tasks/GitCommitTest.groovy
+++ b/src/test/groovy/org/ajoberstar/gradle/git/tasks/GitCommitTest.groovy
@@ -1,0 +1,58 @@
+package org.ajoberstar.gradle.git.tasks
+
+import org.eclipse.jgit.api.Git
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class GitCommitTest extends Specification {
+    Project project
+
+    def testDir = new File("build/tmp/test/${getClass().simpleName}")
+
+    Git localGit
+
+    GitCommit gitCommitTask
+
+    def setup() {
+        localGit = Git.init().setDirectory(testDir).call()
+
+        project = ProjectBuilder.builder().withName("GradleGitPluginTest").withProjectDir(testDir).build()
+        gitCommitTask = project.tasks.add("gitCommit", GitCommit)
+        gitCommitTask.message = 'test'
+
+        project.file("1.txt").withWriter { it << '111' }
+        project.file("2.txt").withWriter { it << '222' }
+        localGit.add().addFilepattern("1.txt").addFilepattern("2.txt").call()
+    }
+
+    def cleanup() {
+        if (testDir.exists()) testDir.deleteDir()
+    }
+
+    def 'should commit only explicitly included files'() {
+        given:
+        gitCommitTask.include('1.txt')
+        when:
+        project.gitCommit.execute()
+        then:
+        localGit.status().call().added == (['2.txt'] as Set<String>)
+    }
+
+    def 'should commit only explicitly not excluded files'() {
+        given:
+        gitCommitTask.include('*.txt')
+        gitCommitTask.exclude('2.txt')
+        when:
+        project.gitCommit.execute()
+        then:
+        localGit.status().call().added == (['2.txt'] as Set<String>)
+    }
+
+    def 'when no files config then commit all files'() {
+        when:
+        project.gitCommit.execute()
+        then:
+        localGit.status().call().added.size() == 0
+    }
+}


### PR DESCRIPTION
Added possibility to adjust files for commit using `include` / `exclude` patterns.
Emulation of `git commit ... $fileName$` command

If possible, could you plz review releasing this change as following minor version of plugin ?
