### PR TITLE
make the commit message configurable

### DIFF
--- a/src/main/groovy/org/ajoberstar/gradle/git/plugins/GithubPagesPlugin.groovy
+++ b/src/main/groovy/org/ajoberstar/gradle/git/plugins/GithubPagesPlugin.groovy
@@ -104,7 +104,7 @@ class GithubPagesPlugin implements Plugin<Project> {
 		GitCommit commit = project.tasks.add(COMMIT_TASK_NAME, GitCommit)
 		commit.description = 'Commits all changes to the working gh-pages repo'
 		commit.dependsOn add
-		commit.message = 'Publish of github pages from Gradle'
+		commit.message = { extension.commitMessage }
 		
 		GitPush push = project.tasks.add(PUSH_TASK_NAME, GitPush)
 		push.description = 'Pushes all changes in the working gh-pages repo to Github'

--- a/src/main/groovy/org/ajoberstar/gradle/git/plugins/GithubPagesPluginExtension.groovy
+++ b/src/main/groovy/org/ajoberstar/gradle/git/plugins/GithubPagesPluginExtension.groovy
@@ -45,6 +45,11 @@ class GithubPagesPluginExtension implements AuthenticationSupported {
 	 * The path to put the github repository in.
 	 */
 	Object workingPath = "${project.buildDir}/ghpages"
+    
+    /**
+     * The message for the git commit command
+     */
+    String commitMessage = "Publish of github pages from Gradle"
 	
 	/**
 	 * Constructs the plugin extension.


### PR DESCRIPTION
I want to use this plugin in order to publish my artifacts to Github. In order to do that, I need to configure the commit message, to always reflect the artifacts beeing uploaded.
Thanks.
