### PR TITLE
Add GitInit for making new local repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ github.credentials.password = password
 
 ## Release Notes
 
+**v0.6.2**
+* Added `GitInit` to simply initialize a new local Git repo. Contributed by [Rasmus Praestholm](https://github.com/Cervator)
+
 **v0.6.1**
 * Updated `GitPush` to support specifying branch names or specs to push. Contributed by [Benjamin Muschko](https://github.com/bmuschko)
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ apply plugin: 'github-pages'
 
 group = 'org.ajoberstar'
 description = 'Git plugins for Gradle'
-version = '0.6.1'
+version = '0.6.2'
 
 sourceCompatibility = '1.5'
 

--- a/src/main/groovy/org/ajoberstar/gradle/git/tasks/GitInit.java
+++ b/src/main/groovy/org/ajoberstar/gradle/git/tasks/GitInit.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2012-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ajoberstar.gradle.git.tasks;
+
+import org.eclipse.jgit.api.InitCommand;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.File;
+
+/**
+ * Task to initialize a new Git repository on the local system.
+ * @since 0.6.2
+ * @author Rasmus 'Cervator' Praestholm <cervator@gmail.com>
+ */
+public class GitInit extends DefaultTask
+{
+	private boolean bare = false;
+	private Object destinationPath = null;
+
+	/**
+	 * Initializes a new local Git repository as configured.
+	 */
+	@TaskAction
+	public void initRepo() {
+        InitCommand cmd = new InitCommand();
+		cmd.setBare(getBare());
+		cmd.setDirectory(getDestinationDir());
+		try {
+			cmd.call();
+		} catch (GitAPIException e) {
+			throw new GradleException("Problem with initializing new Git repo.", e);
+		}
+	}
+	
+	/**
+	 * Gets whether the repository will be bare.
+	 * @return whether the repo will be bare
+	 */
+	@Input
+	public boolean getBare() {
+		return bare;
+	}
+	
+	/**
+	 * Sets whether the repository will be bare.
+	 * @param bare whether the repo will be bare
+	 */
+	public void setBare(boolean bare) {
+		this.bare = bare;
+	}
+	
+	/**
+	 * Gets the destination directory the repository
+	 * will be initialized into.
+	 * @return the path to initialized into
+	 */
+	@OutputDirectory
+	public File getDestinationDir() {
+		return getProject().file(destinationPath);
+	}
+	
+	/**
+	 * Sets the path the repository should be initialized into.
+	 * Will be evaluated using {@link org.gradle.api.Project#file(Object)}.
+	 * @param destinationPath the path to initialize into
+	 */
+	public void setDestinationPath(Object destinationPath) {
+		this.destinationPath = destinationPath;
+	}
+}


### PR DESCRIPTION
Over at MovingBlocks/Terasology we're playing with a fancy multi-repo Git setup and I've prepared some initial Gradle magic in a test organization. Was missing a simple way to initialize new local repos that would flow well with everything else and got this new task to work :-)

I tested it locally after building and deploying to our Artifactory - http://artifactory.movingblocks.net/artifactory/webapp/browserepo.html?22&pathId=libs-release-local:org/ajoberstar/gradle-git/0.6.2/gradle-git-0.6.2.jar

The GitInit task works fine, but my dependency-fu is failing me so my version can't do much of anything else as it fails to find the jcraft stuff from 0.6 for me - might be because I started with a 0.5 pom or something. Fun with caching, perhaps.

I suspect when built properly it'll work for the other stuff too. Or even tested as-is on a different machine. So I thought I'd send it this way :-)

For local build convenience I added:

ext {
    // Defaults so this script will run even without credentials available (but of course uploadArchives will fail if so)
    sonatypeUserName = 'none'
    sonatypePassword = 'none'
}

Was considering adding that in a separate PR but then versioning fun might happen ;-)

So FYI if you would be interested in adding that sometime, I'd like to think passing in the properties would override those.

I based this on GitClone and if it works out I might later try to sort out a way to automatically add a remote ref too.

Thanks for the great plugin!
