### PR TITLE
Support gitflow style release branches 2.x release/2.x release-2.x

### DIFF
--- a/src/main/groovy/org/ajoberstar/gradle/git/release/opinion/Strategies.groovy
+++ b/src/main/groovy/org/ajoberstar/gradle/git/release/opinion/Strategies.groovy
@@ -83,6 +83,20 @@ final class Strategies {
 
 		/**
 		 * Enforces that the normal version complies with the current branch's major version.
+		 * If the branch is not in the format {@code release/#.x} (e.g. {@code release/2.x}) or 
+		 * {@code release-#.x} (e.g. {@code release-3.x}, this will do nothing.
+		 *
+		 * <ul>
+		 *   <li>If the current branch doesn't match the pattern do nothing.</li>
+		 *   <li>If the the nearest normal already complies with the branch name.</li>
+		 *   <li>If the major component can be incremented to comply with the branch, do so.</li>
+		 *   <li>Otherwise fail, because the version can't comply with the branch.</li>
+		 * </ul>
+		 */
+		static final PartialSemVerStrategy ENFORCE_GITFLOW_BRANCH_MAJOR_X = fromBranchPattern(~/^release(?:\/|-)(\d+)\.x$/)
+
+		/**
+		 * Enforces that the normal version complies with the current branch's major version.
 		 * If the branch is not in the format {@code #.#.x} (e.g. {@code 2.3.x}), this will do
 		 * nothing.
 		 *
@@ -95,6 +109,20 @@ final class Strategies {
 		 * </ul>
 		 */
 		static final PartialSemVerStrategy ENFORCE_BRANCH_MAJOR_MINOR_X = fromBranchPattern(~/^(\d+)\.(\d+)\.x$/)
+
+		/**
+		 * Enforces that the normal version complies with the current branch's major version.
+		 * If the branch is not in the format {@code release/#.#.x} (e.g. {@code release/2.3.x}) or 
+		 * {@code release-#.#.x} (e.g. {@code release-3.11.x}, this will do nothing.
+		 *
+		 * <ul>
+		 *   <li>If the current branch doesn't match the pattern do nothing.</li>
+		 *   <li>If the the nearest normal already complies with the branch name.</li>
+		 *   <li>If the major component can be incremented to comply with the branch, do so.</li>
+		 *   <li>Otherwise fail, because the version can't comply with the branch.</li>
+		 * </ul>
+		 */
+		static final PartialSemVerStrategy ENFORCE_GITFLOW_BRANCH_MAJOR_MINOR_X = fromBranchPattern(~/^release(?:\/|-)(\d+)\.(\d+)\.x$/)
 
 		/**
 		 * Uses the specified pattern to enforce that versions inferred on this branch

--- a/src/test/groovy/org/ajoberstar/gradle/git/release/opinion/StrategiesSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/gradle/git/release/opinion/StrategiesSpec.groovy
@@ -105,6 +105,22 @@ class StrategiesSpec extends Specification {
 		'3.1.2' | null
 	}
 
+	def 'Normal.ENFORCE_GITFLOW_BRANCH_MAJOR_X correctly increments version to comply with branch'() {
+		given:
+		def initialState = new SemVerStrategyState(
+			nearestVersion: new NearestVersion(normal: Version.valueOf(nearest)),
+			currentBranch: new Branch(fullName: "refs/heads/${branch}"))
+		expect:
+		Strategies.Normal.ENFORCE_GITFLOW_BRANCH_MAJOR_X.infer(initialState) ==
+			initialState.copyWith(inferredNormal: inferred)
+		where:
+		branch        | nearest | inferred
+		'release/3.x' | '2.0.0' | '3.0.0'
+		'release-3.x' | '2.3.4' | '3.0.0'
+		'release-3.x' | '3.0.0' | null
+		'release/3.x' | '3.1.0' | null
+	}
+
 	def 'Normal.ENFORCE_BRANCH_MAJOR_MINOR_X fails if nearest normal can\'t be incremented to something that complies with branch'() {
 		given:
 		def initialState = new SemVerStrategyState(
@@ -137,6 +153,22 @@ class StrategiesSpec extends Specification {
 		'3.2.x' | '3.1.2' | '3.2.0'
 		'3.2.x' | '3.2.0' | null
 		'3.2.x' | '3.2.1' | null
+	}
+
+	def 'Normal.ENFORCE_GITFLOW_BRANCH_MAJOR_MINOR_X correctly increments version to comply with branch'() {
+		given:
+		def initialState = new SemVerStrategyState(
+			nearestVersion: new NearestVersion(normal: Version.valueOf(nearest)),
+			currentBranch: new Branch(fullName: "refs/heads/${branch}"))
+		expect:
+		Strategies.Normal.ENFORCE_GITFLOW_BRANCH_MAJOR_MINOR_X.infer(initialState) ==
+			initialState.copyWith(inferredNormal: inferred)
+		where:
+		branch          | nearest | inferred
+		'release/3.0.x' | '2.0.0' | '3.0.0'
+		'release-3.0.x' | '3.0.0' | null
+		'release-3.2.x' | '3.1.2' | '3.2.0'
+		'release/3.2.x' | '3.2.1' | null
 	}
 
 	def 'Normal.useScope correctly increments normal'() {


### PR DESCRIPTION
Change the regexes checking for release branches to support the common gitflow prefixes.
