### PR TITLE
Fixes #104 Add an alpha beta versioning strategy 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ dependencies {
 
 	// testing
 	testCompile 'junit:junit:4.10'
-	testCompile 'org.spockframework:spock-core:1.0-groovy-2.3-SNAPSHOT'
+	testCompile 'org.spockframework:spock-core:1.1-groovy-2.3-SNAPSHOT'
 	testRuntime 'cglib:cglib-nodep:3.1'
 }
 

--- a/src/main/groovy/org/ajoberstar/gradle/git/release/opinion/Strategies.groovy
+++ b/src/main/groovy/org/ajoberstar/gradle/git/release/opinion/Strategies.groovy
@@ -82,7 +82,7 @@ final class Strategies {
 
 		/**
 		 * Enforces that the normal version complies with the current branch's major version.
-		 * If the branch is not in the format {@code release/#.x} (e.g. {@code release/2.x}) or 
+		 * If the branch is not in the format {@code release/#.x} (e.g. {@code release/2.x}) or
 		 * {@code release-#.x} (e.g. {@code release-3.x}, this will do nothing.
 		 *
 		 * <ul>
@@ -111,7 +111,7 @@ final class Strategies {
 
 		/**
 		 * Enforces that the normal version complies with the current branch's major version.
-		 * If the branch is not in the format {@code release/#.#.x} (e.g. {@code release/2.3.x}) or 
+		 * If the branch is not in the format {@code release/#.#.x} (e.g. {@code release/2.3.x}) or
 		 * {@code release-#.#.x} (e.g. {@code release-3.11.x}, this will do nothing.
 		 *
 		 * <ul>
@@ -335,5 +335,16 @@ final class Strategies {
 	static final SemVerStrategy FINAL = DEFAULT.copyWith(
 		name: 'final',
 		stages: ['final'] as SortedSet
+	)
+
+	/**
+	 * Provides "alpha", "beta" and "rc" stages that can only be used in clean repos
+	 * and will enforce precedence. The pre-release-alpha-beta component will always be set
+	 * to the stage with an incremented count to disambiguate successive
+	 * releases of the same stage. No build metadata component will be added.
+	 */
+	static final SemVerStrategy PRE_RELEASE_ALPHA_BETA = PRE_RELEASE.copyWith(
+		name: 'pre-release-alpha-beta',
+		stages: ['alpha', 'beta', 'rc'] as SortedSet
 	)
 }

--- a/src/test/groovy/org/ajoberstar/gradle/git/release/opinion/StrategiesSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/gradle/git/release/opinion/StrategiesSpec.groovy
@@ -377,6 +377,30 @@ class StrategiesSpec extends Specification {
 		'MINOR' | 'final'     | '1.0.0'       | '1.1.0-alpha.2'     | false     | '1.1.0'
 	}
 
+	def 'PRE_RELEASE_ALPHA_BETA works as expected'() {
+		def project = mockProject(scope, stage)
+		def grgit = mockGrgit(repoDirty)
+		def locator = mockLocator(nearestNormal, nearestAny)
+		expect:
+		Strategies.PRE_RELEASE.doInfer(project, grgit, locator) == new ReleaseVersion(expected, nearestNormal, true)
+		where:
+		scope   | stage       | nearestNormal | nearestAny          | repoDirty | expected
+		null    | null        | '1.0.0'       | '1.0.0'             | false     | '1.0.1-alpha.1'
+		null    | 'alpha'     | '1.0.0'       | '1.0.0'             | false     | '1.0.1-alpha.1'
+		null    | 'beta'      | '1.0.0'       | '1.0.0'             | false     | '1.0.1-beta.1'
+		null    | 'rc'        | '1.0.0'       | '1.0.0'             | false     | '1.0.1-rc.1'
+		'PATCH' | 'alpha'     | '1.0.0'       | '1.0.0'             | false     | '1.0.1-alpha.1'
+		'MINOR' | 'alpha'     | '1.0.0'       | '1.0.0'             | false     | '1.1.0-alpha.1'
+		'MAJOR' | 'alpha'     | '1.0.0'       | '1.0.0'             | false     | '2.0.0-alpha.1'
+		'PATCH' | 'beta'      | '1.0.0'       | '1.0.0'             | false     | '1.0.1-beta.1'
+		'MINOR' | 'beta'      | '1.0.0'       | '1.0.0'             | false     | '1.1.0-beta.1'
+		'MAJOR' | 'beta'      | '1.0.0'       | '1.0.0'             | false     | '2.0.0-beta.1'
+		null    | 'rc'        | '1.0.0'       | '1.1.0-beta.1'      | false     | '1.1.0-rc.1'
+		null    | 'beta'      | '1.0.0'       | '1.1.0-beta.1'      | false     | '1.1.0-beta.2'
+		null    | 'rc'        | '1.0.0'       | '1.1.0-rc'          | false     | '1.1.0-rc.1'
+		null    | 'rc'        | '1.0.0'       | '1.1.0-rc.4.dev.1'  | false     | '1.1.0-rc.5'
+	}
+
 	def mockProject(String scope, String stage) {
 		Project project = Mock()
 

--- a/src/test/groovy/org/ajoberstar/gradle/git/release/opinion/StrategiesSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/gradle/git/release/opinion/StrategiesSpec.groovy
@@ -382,7 +382,7 @@ class StrategiesSpec extends Specification {
 		def grgit = mockGrgit(repoDirty)
 		def locator = mockLocator(nearestNormal, nearestAny)
 		expect:
-		Strategies.PRE_RELEASE.doInfer(project, grgit, locator) == new ReleaseVersion(expected, nearestNormal, true)
+		Strategies.PRE_RELEASE_ALPHA_BETA.doInfer(project, grgit, locator) == new ReleaseVersion(expected, nearestNormal, true)
 		where:
 		scope   | stage       | nearestNormal | nearestAny          | repoDirty | expected
 		null    | null        | '1.0.0'       | '1.0.0'             | false     | '1.0.1-alpha.1'


### PR DESCRIPTION
- Built upon `PRE_RELEASE` to provide an `alpha`, `beta` and `rc` stages
- Added a spec to test the changes
- Replaced `v1.0-groovy-2.3-SNAPSHOT` with `v1.1-groovy-2.3-SNAPSHOT` as the previous version couldn't be found. See [here](https://oss.sonatype.org/content/repositories/snapshots/org/spockframework/spock-core/) 