### PR TITLE
Issue 108 Split-off prepare- from publishGhPages

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{java,groovy}]
+charset = utf-8
+indent_style = tab

--- a/src/test/groovy/org/ajoberstar/gradle/git/ghpages/GithubPagesPluginExtensionSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/gradle/git/ghpages/GithubPagesPluginExtensionSpec.groovy
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ajoberstar.gradle.git.ghpages
+
+import org.ajoberstar.gradle.git.auth.BasicPasswordCredentials
+import org.gradle.api.Project
+import org.gradle.api.file.CopySpec
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class GithubPagesPluginExtensionSpec extends Specification {
+	Project project = ProjectBuilder.builder().build()
+
+	def 'Verify the defaults'() {
+		def ext = new GithubPagesPluginExtension(project)
+
+		expect:
+		ext.commitMessage == 'Publish of Github pages from Gradle.'
+		ext.credentials instanceof BasicPasswordCredentials
+		ext.pages instanceof CopySpec
+		ext.targetBranch == 'gh-pages'
+		ext.workingDir == project.file("${project.buildDir}/ghpages")
+		ext.workingPath == "${project.buildDir}/ghpages"
+		ext.deleteExistingFiles
+		!ext.repoUri
+	}
+
+	@Unroll
+	def 'Repo uri [#repoUri] results in [#expected]'() {
+		def ext = new GithubPagesPluginExtension(project)
+		ext.repoUri = repoUri
+
+		expect:
+		ext.getRepoUri() == expected
+
+		where:
+		repoUri                        || expected
+		'git@domain.tld:user/repo.git' || 'git@domain.tld:user/repo.git'
+		// as repoUri is an Object which gets "unpacked", I expect there are
+		// use-cases for this. But I've none
+	}
+
+	def 'WorkingDir is based on workingPath'() {
+		def ext = new GithubPagesPluginExtension(project)
+		ext.workingPath = "${project.buildDir}/some-path"
+
+		when:
+		def workingDir = ext.getWorkingDir()
+
+		then:
+		workingDir.absolutePath.endsWith(old(ext.workingPath))
+	}
+}

--- a/src/test/groovy/org/ajoberstar/gradle/git/ghpages/GithubPagesPluginSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/gradle/git/ghpages/GithubPagesPluginSpec.groovy
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ajoberstar.gradle.git.ghpages
+
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class GithubPagesPluginSpec extends Specification {
+	public static final String PLUGIN_NAME = 'org.ajoberstar.github-pages'
+	public static final String EXTENSION_NAME = 'githubPages'
+	Project project = ProjectBuilder.builder().build()
+
+	def 'Creates the [githubPages] extension'() {
+		assert !project.plugins.hasPlugin(PLUGIN_NAME)
+		assert !project.extensions.findByName(EXTENSION_NAME)
+
+		when:
+		project.plugins.apply(PLUGIN_NAME)
+
+		then:
+		def extension = project.extensions.findByName(EXTENSION_NAME)
+		extension instanceof GithubPagesPluginExtension
+	}
+
+	@Unroll
+	def 'Implements the [#taskName] task'() {
+		assert !project.plugins.hasPlugin(PLUGIN_NAME)
+		assert !project.tasks.findByName(taskName)
+
+		when:
+		project.plugins.apply(PLUGIN_NAME)
+
+		then:
+		project.tasks.findByName(taskName)
+
+		where:
+		taskName         || _
+		'prepareGhPages' || _
+		'publishGhPages' || _
+	}
+
+	def '[publishGhPages] task depends on [prepareGhPages] tasks'() {
+		project.plugins.apply(PLUGIN_NAME)
+
+		when:
+		def task = project.tasks.findByName('publishGhPages')
+
+		then:
+		task.taskDependencies.getDependencies(task).find { Task it ->
+			it.name == 'prepareGhPages'
+		}
+	}
+
+	@Unroll
+	def 'Task [#taskName] has description [#description]'() {
+		project.plugins.apply(PLUGIN_NAME)
+
+		when:
+		def task = project.tasks.findByName(taskName)
+
+		then:
+		task.description == description
+
+		where:
+		taskName         || description
+		'prepareGhPages' || 'Prepare the gh-pages changes locally'
+		'publishGhPages' || 'Publishes all gh-pages changes to Github'
+	}
+}


### PR DESCRIPTION
Step 1 on #108

I've also added a `.editorconfig` file which defines a coding style which can be used by one of the many EditorConfig plugins, see http://editorconfig.org/ for all details.
I've now configured it to use tab indents for java/groovy files, as I noticed that you used tab-indents.