### PR TITLE
Fixes issue #149

### DIFF
--- a/src/main/groovy/org/ajoberstar/gradle/git/release/opinion/OpinionReleasePlugin.groovy
+++ b/src/main/groovy/org/ajoberstar/gradle/git/release/opinion/OpinionReleasePlugin.groovy
@@ -64,7 +64,7 @@ class OpinionReleasePlugin implements Plugin<Project> {
 					builder << version.version
 					builder << '\n\n'
 
-					String previousVersion = "v${version.previousVersion}^{commit}"
+					String previousVersion = "${project.release.tagStrategy.prefixNameWithV ? "v" : ""}${version.previousVersion}^{commit}"
 					List excludes = []
 					if (tagExists(grgit, previousVersion)) {
 						excludes << previousVersion

--- a/src/test/groovy/org/ajoberstar/gradle/git/release/opinion/OpinionReleasePluginSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/gradle/git/release/opinion/OpinionReleasePluginSpec.groovy
@@ -60,6 +60,28 @@ Release of 1.2.3
 '''.trim()
 	}
 
+	def 'plugin tag strategy creates correct message if previous tag exists and no prefix with v'() {
+		given:
+		project.plugins.apply('org.ajoberstar.release-opinion')
+		Grgit grgit = GroovyMock()
+		project.release.grgit = grgit
+		project.release.tagStrategy.prefixNameWithV = false
+		ResolveService resolve = Mock()
+		(1.._) * grgit.resolve >> resolve
+		1 * resolve.toCommit('1.2.2^{commit}') >> new Commit(shortMessage: 'Commit 1')
+		1 * grgit.log([includes: ['HEAD'], excludes: ['1.2.2^{commit}']]) >> [
+				new Commit(shortMessage: 'Commit 2'),
+				new Commit(shortMessage: 'Next commit')]
+		0 * grgit._
+		expect:
+		project.release.tagStrategy.generateMessage(version).trim() == '''
+Release of 1.2.3
+
+- Commit 2
+- Next commit
+'''.trim()
+	}
+
 	def 'plugin tag strategy creates correct message if previous tag does not exist'() {
 		given:
 		project.plugins.apply('org.ajoberstar.release-opinion')


### PR DESCRIPTION
Release message will be properly generated when using `release.tagStrategy.prefixNameWithV = false`, previously the prior tag wouldn't be found.