### PR TITLE
Fix NPE when defaultVersionStrategy is used with no stage defined + Extends Logging for default strategy

### DIFF
--- a/src/main/groovy/org/ajoberstar/gradle/git/release/semver/SemVerStrategy.groovy
+++ b/src/main/groovy/org/ajoberstar/gradle/git/release/semver/SemVerStrategy.groovy
@@ -98,7 +98,7 @@ final class SemVerStrategy implements DefaultVersionStrategy {
 	@Override
 	boolean defaultSelector(Project project, Grgit grgit) {
 		String stage = getPropertyOrNull(project, STAGE_PROP)
-		if (!stages.contains(stage)) {
+		if (stage != null && !stages.contains(stage)) {
 			logger.info('Skipping {} default strategy because stage ({}) is not one of: {}', name, stage, stages)
 			return false
 		} else if (!allowDirtyRepo && !grgit.status().clean) {

--- a/src/main/groovy/org/ajoberstar/gradle/git/release/semver/SemVerStrategy.groovy
+++ b/src/main/groovy/org/ajoberstar/gradle/git/release/semver/SemVerStrategy.groovy
@@ -105,6 +105,8 @@ final class SemVerStrategy implements DefaultVersionStrategy {
 			logger.info('Skipping {} default strategy because repo is dirty.', name)
 			return false
 		} else {
+			String status = grgit.status().clean ? 'clean' : 'dirty'
+			logger.info('Using {} default strategy because repo is {} and no stage defined', name, status)
 			return true
 		}
 	}

--- a/src/test/groovy/org/ajoberstar/gradle/git/release/semver/SemVerStrategySpec.groovy
+++ b/src/test/groovy/org/ajoberstar/gradle/git/release/semver/SemVerStrategySpec.groovy
@@ -72,6 +72,54 @@ class SemVerStrategySpec extends Specification {
 		strategy.selector(project, grgit)
 	}
 
+	def 'default selector returns false if stage is defined but not set to valid value'() {
+		given:
+		def strategy = new SemVerStrategy(stages: ['one', 'two'] as SortedSet)
+		mockStage('test')
+		expect:
+		!strategy.defaultSelector(project, grgit)
+	}
+
+	def 'default selector returns true if stage is not defined'() {
+		given:
+		def strategy = new SemVerStrategy(stages: ['one', 'two'] as SortedSet)
+		mockStage(null)
+		mockRepoClean(true)
+		expect:
+		strategy.defaultSelector(project, grgit)
+	}
+
+	def 'default selector returns false if repo is dirty and not allowed to be'() {
+		given:
+		def strategy = new SemVerStrategy(stages: ['one'] as SortedSet, allowDirtyRepo: false)
+		mockStage(stageProp)
+		mockRepoClean(false)
+		expect:
+		!strategy.defaultSelector(project, grgit)
+		where:
+		stageProp << [null, 'one']
+	}
+
+	def 'default  selector returns true if repo is dirty and allowed and other criteria met'() {
+		given:
+		def strategy = new SemVerStrategy(stages: ['one'] as SortedSet, allowDirtyRepo: true)
+		mockStage('one')
+		mockRepoClean(false)
+		mockBranchService()
+		expect:
+		strategy.defaultSelector(project, grgit)
+	}
+
+	def 'default selector returns true if all criteria met'() {
+		given:
+		def strategy = new SemVerStrategy(stages: ['one', 'and'] as SortedSet, allowDirtyRepo: false)
+		mockStage('one')
+		mockRepoClean(true)
+		mockBranchService()
+		expect:
+		strategy.defaultSelector(project, grgit)
+	}
+
 	def 'infer returns correct version'() {
 		given:
 		mockScope(scope)


### PR DESCRIPTION
A NPE occurs if the defaultVersionStrategy is used but no stage is defined. 
In my opinion, the behaviour should be: when no stage is defined, just take the defined defaultStrategy (respecting that strategy might not be valid for dirty repositories)