### PR TITLE
Don't pass a version to the rootProject any more, but only to subproj…

### DIFF
--- a/src/main/groovy/org/ajoberstar/gradle/git/release/base/ReleasePluginExtension.groovy
+++ b/src/main/groovy/org/ajoberstar/gradle/git/release/base/ReleasePluginExtension.groovy
@@ -66,7 +66,9 @@ class ReleasePluginExtension {
     ReleasePluginExtension(Project project) {
         this.project = project
         def sharedVersion = new DelayedVersion()
-        project.rootProject.allprojects {
+
+        project.version = sharedVersion
+        project.subprojects {
             version = sharedVersion
         }
     }


### PR DESCRIPTION
Had the following Problem:
Three GIT-Repositories. One is root, and two are just cloned into the root.
But the root project itself has a settings.gradle where the other two sub-projects are included.

```
root
- A
- B
```

All projects have different tags


```
root (7.4.0)
- A (2.3.0)
- B (0.0.1)
```

Currently it isn't possible to apply the plugin to all three projects and also maintain the version independent, because the project which is evaluated latest applies its version to `project.rootProject.allprojects`.

I changed that and a applied plugin will only add the version to itself, and to their sub-projects.