### PR TITLE
Lost commit when running the prepareGhPages and publishGhPages tasks separately

### DIFF
--- a/src/main/groovy/org/ajoberstar/gradle/git/ghpages/GithubPagesPlugin.groovy
+++ b/src/main/groovy/org/ajoberstar/gradle/git/ghpages/GithubPagesPlugin.groovy
@@ -19,6 +19,7 @@ import org.ajoberstar.grgit.Grgit
 import org.ajoberstar.grgit.operation.ResetOp
 import org.ajoberstar.grgit.exception.GrgitException
 import org.eclipse.jgit.errors.RepositoryNotFoundException
+import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -59,7 +60,8 @@ class GithubPagesPlugin implements Plugin<Project> {
             with extension.pages.realSpec
             into { extension.workingDir }
             doFirst {
-                def repo = repo(project, extension)
+                def repo = repo(extension)
+                resetRepo(repo, extension)
                 if (extension.deleteExistingFiles) {
                     def relDestDir = extension.pages.relativeDestinationDir
                     def targetDir = new File(extension.workingDir, relDestDir)
@@ -74,7 +76,7 @@ class GithubPagesPlugin implements Plugin<Project> {
                 }
             }
             doLast {
-                def repo = repo(project, extension)
+                def repo = repo(extension)
                 repo.with {
                     add(patterns: ['.'])
                     if (status().clean) {
@@ -94,17 +96,17 @@ class GithubPagesPlugin implements Plugin<Project> {
             group = 'publishing'
             // only push if there are commits to push
             onlyIf {
-                def repo = repo(project, extension)
+                def repo = repo(extension)
                 def status = repo.branch.status(name: repo.branch.current)
                 status.aheadCount > 0
             }
             doLast {
-                repo(project, extension).push()
+                repo(extension).push()
             }
         }
     }
 
-    private Grgit repo(Project project, GithubPagesPluginExtension extension) {
+    private Grgit repo(GithubPagesPluginExtension extension) {
         if (extension.ext.has('repo')) {
             return extension.ext.repo
         }
@@ -112,17 +114,6 @@ class GithubPagesPlugin implements Plugin<Project> {
         try {
             // attempt to reuse existing repository
             repo = Grgit.open(dir: extension.workingDir)
-            if (extension.repoUri == repo.remote.list().find { it.name == 'origin' }?.url &&
-                    repo.branch.current.name == extension.targetBranch) {
-                repo.clean(directories: true, ignore: false)
-                repo.fetch()
-                repo.reset(commit: 'origin/' + extension.targetBranch, mode: ResetOp.Mode.HARD)
-            }
-            else {
-                project.logger.warn('Found a git repository at workingDir, but it does not match configuration. A fresh clone will be used.')
-                repo.close()
-                repo = null
-            }
         } catch (RepositoryNotFoundException ignored) {
             // not a git repo
         } catch (GrgitException ignored) {
@@ -147,5 +138,23 @@ class GithubPagesPlugin implements Plugin<Project> {
         }
         extension.ext.repo = repo
         return repo
+    }
+
+    private void resetRepo(Grgit repo, GithubPagesPluginExtension extension) {
+        try {
+            // attempt to reset existing repository to targetBranch
+            if (extension.repoUri == repo.remote.list().find { it.name == 'origin' }?.url &&
+                    repo.branch.current.name == extension.targetBranch) {
+                repo.clean(directories: true, ignore: false)
+                repo.fetch()
+                repo.reset(commit: 'origin/' + extension.targetBranch, mode: ResetOp.Mode.HARD)
+            }
+            else {
+                repo.close()
+                throw new GradleException("Invalid repository at ${extension.workingDir}")
+            }
+        } catch (GrgitException e) {
+            throw new GradleException(e)
+        }
     }
 }


### PR DESCRIPTION
I raised issue #221 and after upgrading and I got what I thought was the same problem. Digging into it, it looks like a later change has introduced a new problem but with the same output, the publish task is skipped.

This PR splits the repo function in GithubPagesPlugin into 3 functions that open the repository, verify it matches the configuration and  resets the repository to the target branch, with only the prepare task calling the reset function.
