### PR TITLE
Check if your project is using any SNAPSHOT dependencies

### DIFF
--- a/src/main/groovy/org/ajoberstar/gradle/git/release/opinion/Strategies.groovy
+++ b/src/main/groovy/org/ajoberstar/gradle/git/release/opinion/Strategies.groovy
@@ -284,6 +284,7 @@ final class Strategies {
         name: '',
         stages: [] as SortedSet,
         allowDirtyRepo: false,
+        allowSnapshotDependencies: false,
         normalStrategy: one(Normal.USE_SCOPE_PROP, Normal.USE_NEAREST_ANY, Normal.useScope(ChangeScope.PATCH)),
         preReleaseStrategy: PreRelease.NONE,
         buildMetadataStrategy: BuildMetadata.NONE,
@@ -300,6 +301,7 @@ final class Strategies {
         name: 'snapshot',
         stages: ['SNAPSHOT'] as SortedSet,
         allowDirtyRepo: true,
+        allowSnapshotDependencies: true,
         preReleaseStrategy: PreRelease.STAGE_FIXED,
         createTag: false,
         enforcePrecedence: false
@@ -318,6 +320,7 @@ final class Strategies {
         name: 'development',
         stages: ['dev'] as SortedSet,
         allowDirtyRepo: true,
+        allowSnapshotDependencies: true,
         preReleaseStrategy: all(PreRelease.STAGE_FLOAT, PreRelease.COUNT_COMMITS_SINCE_ANY, PreRelease.SHOW_UNCOMMITTED),
         buildMetadataStrategy: BuildMetadata.COMMIT_ABBREVIATED_ID,
         createTag: false


### PR DESCRIPTION
 Added 'allowSnapshotDependencies' property to SemVerStrategy. Used to fail the release task when using any SNAPSHOT dependencies. Functionality is similar to the the [gradle-release](https://github.com/researchgate/gradle-release) plugin. The implementation is similar to 'allowDirtyRepo'.