### PR TITLE
Fix username-only credentials

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     compile gradleApi()
 
     // grgit
-    compile 'org.ajoberstar:grgit:1.9.0'
+    compile 'org.ajoberstar:grgit:1.9.1'
 
     // semver
     compile 'com.github.zafarkhaja:java-semver:0.9.0'

--- a/src/main/groovy/org/ajoberstar/gradle/git/release/semver/RebuildVersionStrategy.groovy
+++ b/src/main/groovy/org/ajoberstar/gradle/git/release/semver/RebuildVersionStrategy.groovy
@@ -53,14 +53,14 @@ class RebuildVersionStrategy implements VersionStrategy {
     @Override
     boolean selector(Project project, Grgit grgit) {
         def clean = grgit.status().clean
-        def props = project.properties.keySet().find { it.startsWith('release.') }
+        def propsSpecified = project.hasProperty(SemVerStrategy.SCOPE_PROP) || project.hasProperty(SemVerStrategy.STAGE_PROP)
         def headVersion = getHeadVersion(project, grgit)
 
-        if (clean && props == null && headVersion) {
+        if (clean && !propsSpecified && headVersion) {
             logger.info('Using {} strategy because repo is clean, no "release." properties found and head version is {}', name, headVersion)
             return true
         } else {
-            logger.info('Skipping {} strategy because clean is {}, "release." properties are {} and head version is {}', name, clean, props, headVersion)
+            logger.info('Skipping {} strategy because clean is {}, "release." properties are {} and head version is {}', name, clean, propsSpecified, headVersion)
             return false
         }
     }

--- a/src/test/groovy/org/ajoberstar/gradle/git/release/semver/RebuildVersionStrategySpec.groovy
+++ b/src/test/groovy/org/ajoberstar/gradle/git/release/semver/RebuildVersionStrategySpec.groovy
@@ -51,7 +51,7 @@ class RebuildVersionStrategySpec extends Specification {
     def 'selector returns false if any release properties are set'() {
         given:
         mockClean(true)
-        Project project = getProject('release.anything': 'value')
+        Project project = getProject('release.scope': 'value')
         mockTagsAtHead('v1.0.0')
         expect:
         !strategy.selector(project, grgit)


### PR DESCRIPTION
Grgit 1.9.1 fixed the issue with exceptions when you only provide a
username, e.g. when using GitHub personal access tokens.

Fixes #250