### PR TITLE
Don't silently swallow an exception

### DIFF
--- a/src/main/groovy/org/ajoberstar/gradle/git/base/GrgitPlugin.groovy
+++ b/src/main/groovy/org/ajoberstar/gradle/git/base/GrgitPlugin.groovy
@@ -36,11 +36,11 @@ class GrgitPlugin implements Plugin<Project> {
             project.rootProject.allprojects { prj ->
                 project.ext.grgit = grgit
             }
-        } catch (RepositoryNotFoundException e1 | GrgitException e2) {
+        } catch (RepositoryNotFoundException | GrgitException e) {
             // not a git repo or invalid/corrupt
-            String msg = "No git repository found in ${project.rootProject.rootDir}"
+            String msg = "No git repository found in ${project.rootProject.rootDir} (${e.message)"
             project.logger.error msg
-            throw new GradleException(msg, e1 ?: e2)
+            throw new GradleException(msg, e)
         }
     }
 }

--- a/src/main/groovy/org/ajoberstar/gradle/git/base/GrgitPlugin.groovy
+++ b/src/main/groovy/org/ajoberstar/gradle/git/base/GrgitPlugin.groovy
@@ -20,6 +20,7 @@ import org.ajoberstar.grgit.exception.GrgitException
 import org.eclipse.jgit.errors.RepositoryNotFoundException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.GradleException
 
 /**
  * Plugin adding a {@code grgit} property to all projects
@@ -35,9 +36,11 @@ class GrgitPlugin implements Plugin<Project> {
             project.rootProject.allprojects { prj ->
                 project.ext.grgit = grgit
             }
-        } catch (RepositoryNotFoundException | GrgitException ignored) {
+        } catch (RepositoryNotFoundException e1 | GrgitException e2) {
             // not a git repo or invalid/corrupt
-            project.logger.warn 'No git repository found. Build may fail with NPE.'
+            String msg = "No git repository found in ${project.rootProject.rootDir}"
+            project.logger.error msg
+            throw new GradleException(msg, e1 ?: e2)
         }
     }
 }

--- a/src/main/groovy/org/ajoberstar/gradle/git/base/GrgitPlugin.groovy
+++ b/src/main/groovy/org/ajoberstar/gradle/git/base/GrgitPlugin.groovy
@@ -38,7 +38,7 @@ class GrgitPlugin implements Plugin<Project> {
             }
         } catch (RepositoryNotFoundException | GrgitException e) {
             // not a git repo or invalid/corrupt
-            String msg = "No git repository found in ${project.rootProject.rootDir} (${e.message)"
+            String msg = "No git repository found in ${project.rootProject.rootDir} (${e.message})"
             project.logger.error msg
             throw new GradleException(msg, e)
         }


### PR DESCRIPTION
If we apply the plugin on project and the Git repo is not found there or is corrupted, then it's IMHO critical failure.